### PR TITLE
Add UE_LOG to Macros that will not generate indent on the next line

### DIFF
--- a/ue4_smarter_macro_indenting.vcmd
+++ b/ue4_smarter_macro_indenting.vcmd
@@ -17,7 +17,7 @@ public class E : VisualCommanderExt.IExtension
 {
     private EnvDTE80.DTE2 _DTE;
     private EnvDTE80.TextDocumentKeyPressEvents _textDocumentKeyPressEvents;
-    private static readonly string MACRO_REGEX = @"^(?&lt;leading_whitespace&gt;[\s]*)(UPROPERTY|UFUNCTION|GENERATED_(USTRUCT_|UCLASS_|(U|I)INTERFACE_)?BODY)\(.*";
+    private static readonly string MACRO_REGEX = @"^(?&lt;leading_whitespace&gt;[\s]*)(UPROPERTY|UFUNCTION|UE_LOG|GENERATED_(USTRUCT_|UCLASS_|(U|I)INTERFACE_)?BODY)\(.*";
     private static readonly string TEXT_WITH_WS_REGEX = @"(?&lt;leading_whitespace&gt;[\s]*)\S+";
 
     private CommandEvents _pasteEvent;


### PR DESCRIPTION
Hi ! I'm proposing to add UE_LOG into the list of macros in the regular expression. I've already tested it on my side and works well.