### PR TITLE
Ignore UE_LOG macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This extension was designed to fix the unnecessary and annoying "smart" indentin
 * GENERATED_USTRUCT_BODY
 * GENERATED_UINTERFACE_BODY
 * GENERATED_IINTERFACE_BODY
-* UE_LOG
 
 ### Demo
 | Before | After |

--- a/ue4_smarter_macro_indenting_vs2013-2015.vcmd
+++ b/ue4_smarter_macro_indenting_vs2013-2015.vcmd
@@ -17,7 +17,7 @@ public class E : VisualCommanderExt.IExtension
 {
     private EnvDTE80.DTE2 _DTE;
     private EnvDTE80.TextDocumentKeyPressEvents _textDocumentKeyPressEvents;
-    private static readonly string MACRO_REGEX = @"^(?&lt;leading_whitespace&gt;[\s]*)(UPROPERTY|UFUNCTION|UE_LOG|GENERATED_(USTRUCT_|UCLASS_|(U|I)INTERFACE_)?BODY)\(.*";
+    private static readonly string MACRO_REGEX = @"^(?&lt;leading_whitespace&gt;[\s]*)(UPROPERTY|UFUNCTION|GENERATED_(USTRUCT_|UCLASS_|(U|I)INTERFACE_)?BODY)\(.*";
     private static readonly string TEXT_WITH_WS_REGEX = @"(?&lt;leading_whitespace&gt;[\s]*)\S+";
 
     private CommandEvents _pasteEvent;

--- a/ue4_smarter_macro_indenting_vs2017-2019.vcmd
+++ b/ue4_smarter_macro_indenting_vs2017-2019.vcmd
@@ -17,7 +17,7 @@ public class E : VisualCommanderExt.IExtension
 {
     private EnvDTE80.DTE2 _DTE;
     private EnvDTE80.TextDocumentKeyPressEvents _textDocumentKeyPressEvents;
-    private static readonly string MACRO_REGEX = @"^(?&lt;leading_whitespace&gt;[\s]*)(UPROPERTY|UFUNCTION|UE_LOG|GENERATED_(USTRUCT_|UCLASS_|(U|I)INTERFACE_)?BODY)\(.*";
+    private static readonly string MACRO_REGEX = @"^(?&lt;leading_whitespace&gt;[\s]*)(UPROPERTY|UFUNCTION|GENERATED_(USTRUCT_|UCLASS_|(U|I)INTERFACE_)?BODY)\(.*";
     private static readonly string TEXT_WITH_WS_REGEX = @"(?&lt;leading_whitespace&gt;[\s]*)\S+";
 
     private CommandEvents _pasteEvent;


### PR DESCRIPTION
UE_LOG macros don't need special handling as there is a semicolon after them, and this was causing odd behavior with removing lines below UE_LOG.

closes #19